### PR TITLE
updating the deployment pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,11 @@
       <plugin>
         <groupId>com.simpligility.maven.plugins</groupId>
         <artifactId>android-maven-plugin</artifactId>
-        <version>4.5.0</version>
+        <version>4.6.0</version>
         <extensions>true</extensions>
         <configuration>
             <sdk>
-                <platform>25</platform>
+                <platform>26</platform>
             </sdk>
         </configuration>
       </plugin>


### PR DESCRIPTION
There's an issue with the deployment using the wrong Google Play URL. I'm hoping that updating the version of this plugin will resolve this problem.